### PR TITLE
fixed bug with FL check when RFL is reset

### DIFF
--- a/analyzeFP.cpp
+++ b/analyzeFP.cpp
@@ -528,6 +528,7 @@ void CVFPCPlugin::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget,
 //
 void CVFPCPlugin::OnFlightPlanDisconnect(CFlightPlan FlightPlan)
 {
+	FlightPlan.GetControllerAssignedData().SetFinalAltitude(NULL);
 	AircraftIgnore.erase(remove(AircraftIgnore.begin(), AircraftIgnore.end(), FlightPlan.GetCallsign()), AircraftIgnore.end());	
 }
 
@@ -869,7 +870,6 @@ void CVFPCPlugin::flUp(CFlightPlan flightPlan) {
 			if (higher == availFls.size()) return;
 			flightPlan.GetControllerAssignedData().SetFinalAltitude(availFls[higher] * 100);
 			flightPlan.GetFlightPlanData().SetFinalAltitude(flightPlan.GetControllerAssignedData().GetFinalAltitude());
-			flightPlan.GetControllerAssignedData().SetFinalAltitude(NULL);
 		}
 	}
 	return;
@@ -1126,7 +1126,6 @@ void CVFPCPlugin::flDown(CFlightPlan flightPlan) {
 			for (i = 0; i < availFls.size(); i++) NULL;
 			flightPlan.GetControllerAssignedData().SetFinalAltitude(availFls[lower] * 100);
 			flightPlan.GetFlightPlanData().SetFinalAltitude(flightPlan.GetControllerAssignedData().GetFinalAltitude());
-			flightPlan.GetControllerAssignedData().SetFinalAltitude(NULL);
 		}
 	}
 	return;


### PR DESCRIPTION
I just discovered that when FL Up or Down has been used, the Flight Level checks stop working because the RFL is reset to NULL after the button has been pressed, this mitigates it by reseting the RFL when the aircraft is airborne.