### PR TITLE
AT3 uncorrelated tag items

### DIFF
--- a/AT3/AT3Tags.cpp
+++ b/AT3/AT3Tags.cpp
@@ -210,19 +210,19 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 
 	switch (ItemCode) {
 		case TAG_ITEM_AT3_ALTITUDE:
-			tagOutput = GetFormattedAltitude(FlightPlan, RadarTarget);
+			tagOutput = GetFormattedAltitude(RadarTarget);
 			goto endSwitch;
 		case TAG_ITEM_AT3_TRACK:
-			tagOutput = GetFormattedTrack(FlightPlan, RadarTarget);
+			tagOutput = GetFormattedTrack(RadarTarget);
 			goto endSwitch;
 		case TAG_ITEM_AT3_SPEED:
-			tagOutput = GetFormattedGroundspeed(FlightPlan, RadarTarget);
+			tagOutput = GetFormattedGroundspeed(RadarTarget);
 			goto endSwitch;
 		case TAG_ITEM_AT3_VS_INDICATOR:
-			tagOutput = GetVSIndicator(FlightPlan, RadarTarget);
+			tagOutput = GetVSIndicator(RadarTarget);
 			goto endSwitch;
 		case TAG_ITEM_AT3_ADSB_CALLSIGN:
-			tagOutput = GetADSBCallsign(FlightPlan, RadarTarget);
+			tagOutput = GetADSBCallsign(RadarTarget);
 			goto endSwitch;
 	}
 
@@ -232,37 +232,37 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 			tagOutput = GetFormattedAltitudedAssigned(FlightPlan, RadarTarget);
 			break;
 		case TAG_ITEM_AT3_HEADING_ASSIGNED:
-			tagOutput = GetFormattedHeadingAssigned(FlightPlan, RadarTarget);
+			tagOutput = GetFormattedHeadingAssigned(FlightPlan);
 			break;
 		case TAG_ITEM_AT3_SPEED_ASSIGNED:
-			tagOutput = GetFormattedSpeedAssigned(FlightPlan, RadarTarget);
+			tagOutput = GetFormattedSpeedAssigned(FlightPlan);
 			break;
 		case TAG_ITEM_AT3_ROUTE_CODE:
-			tagOutput = GetRouteCodeLine4(FlightPlan, RadarTarget);
+			tagOutput = GetRouteCodeLine4(FlightPlan);
 			break;
 		case TAG_ITEM_AT3_APPDEP_LINE4:
-			tagOutput = GetAPPDEPLine4(FlightPlan, RadarTarget);
+			tagOutput = GetAPPDEPLine4(FlightPlan);
 			break;
 		case TAG_ITEM_AT3_AMC_LINE4:
-			tagOutput = GetAMCLine4(FlightPlan, RadarTarget);
+			tagOutput = GetAMCLine4(FlightPlan);
 			break;
 		case TAG_ITEM_AT3_ETA:
-			tagOutput = GetFormattedETA(FlightPlan, RadarTarget, minu);
+			tagOutput = GetFormattedETA(FlightPlan, minu);
 			break;
 		case TAG_ITEM_AT3_DELAY:
-			tagOutput = GetAMANDelay(FlightPlan, RadarTarget);
+			tagOutput = GetAMANDelay(FlightPlan);
 			break;
 		case TAG_ITEM_AT3_CALLSIGN:
-			tagOutput = GetCallsign(FlightPlan, RadarTarget);
+			tagOutput = GetCallsign(FlightPlan);
 			break;
 		case TAG_ITEM_AT3_ATYPWTC:
-			tagOutput = GetATYPWTC(FlightPlan, RadarTarget);
+			tagOutput = GetATYPWTC(FlightPlan);
 			break;
 		case TAG_ITEM_AT3_ARRIVAL_RWY:
-			tagOutput = GetFormattedArrivalRwy(FlightPlan, RadarTarget);
+			tagOutput = GetFormattedArrivalRwy(FlightPlan);
 			break;
 		case TAG_ITEM_AT3_ALRT:
-			tagOutput = GetALRT(FlightPlan, RadarTarget);
+			tagOutput = GetALRT(FlightPlan);
 			*pRGB = colorRedundant;
 			break;
 		default:
@@ -506,7 +506,7 @@ void AT3Tags::OnFunctionCall(int FunctionId, const char* sItemString, POINT Pt, 
 	}
 }
 
-string AT3Tags::GetFormattedAltitude(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetFormattedAltitude(CRadarTarget& RadarTarget)
 {
 	int altitude = RadarTarget.GetPosition().GetPressureAltitude();
 	int transAlt = GetTransitionAltitude();
@@ -596,7 +596,7 @@ string AT3Tags::GetFormattedAltitudedAssigned(CFlightPlan& FlightPlan, CRadarTar
 	return formattedAltAssigned;
 }
 
-string AT3Tags::GetFormattedTrack(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetFormattedTrack(CRadarTarget& RadarTarget)
 {
 	string track = to_string(static_cast<int>(trunc(RadarTarget.GetTrackHeading())));
 
@@ -610,7 +610,7 @@ string AT3Tags::GetFormattedTrack(CFlightPlan& FlightPlan, CRadarTarget& RadarTa
 	return track;
 }
 
-string AT3Tags::GetFormattedHeadingAssigned(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetFormattedHeadingAssigned(CFlightPlan& FlightPlan)
 {
 	string headingAssigned = to_string(FlightPlan.GetControllerAssignedData().GetAssignedHeading());
 	if (headingAssigned == "0") {
@@ -624,7 +624,7 @@ string AT3Tags::GetFormattedHeadingAssigned(CFlightPlan& FlightPlan, CRadarTarge
 	return headingAssigned;
 }
 
-string AT3Tags::GetFormattedGroundspeed(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetFormattedGroundspeed(CRadarTarget& RadarTarget)
 {
 	string groundSpeed = to_string((RadarTarget.GetGS() + 5) / 10);
 	if (groundSpeed.length() <= 2) {
@@ -633,7 +633,7 @@ string AT3Tags::GetFormattedGroundspeed(CFlightPlan& FlightPlan, CRadarTarget& R
 	return groundSpeed;
 }
 
-string AT3Tags::GetFormattedSpeedAssigned(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetFormattedSpeedAssigned(CFlightPlan& FlightPlan)
 {
 	string speedAssigned;
 
@@ -686,7 +686,7 @@ void AT3Tags::GetRouteCode(CFlightPlan& FlightPlan) {
 	}
 }
 
-string AT3Tags::GetRouteCodeLine4(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetRouteCodeLine4(CFlightPlan& FlightPlan)
 {
 	string spadCurrent = FlightPlan.GetControllerAssignedData().GetScratchPadString();
 	string flightStrip = FlightPlan.GetControllerAssignedData().GetFlightStripAnnotation(3);
@@ -750,7 +750,7 @@ void AT3Tags::GetAssignedAPP(CFlightPlan& FlightPlan) {
 	}
 }
 
-string AT3Tags::GetAPPDEPLine4(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetAPPDEPLine4(CFlightPlan& FlightPlan)
 {
 	string flightStrip = FlightPlan.GetControllerAssignedData().GetFlightStripAnnotation(2);
 	string lineStr;
@@ -788,7 +788,7 @@ string AT3Tags::GetAPPDEPLine4(CFlightPlan& FlightPlan, CRadarTarget& RadarTarge
 	return lineStr;
 }
 
-string AT3Tags::GetAMCLine4(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetAMCLine4(CFlightPlan& FlightPlan)
 {
 	string flightStrip = FlightPlan.GetControllerAssignedData().GetFlightStripAnnotation(2);
 	string lineStr;
@@ -821,7 +821,7 @@ string AT3Tags::GetAMCLine4(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
 	return lineStr;
 }
 
-string AT3Tags::GetFormattedETA(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget, int minutes)
+string AT3Tags::GetFormattedETA(CFlightPlan& FlightPlan, int minutes)
 {
 	try {
 		string runway = FlightPlan.GetFlightPlanData().GetArrivalRwy();
@@ -878,7 +878,7 @@ string AT3Tags::GetFormattedETA(CFlightPlan& FlightPlan, CRadarTarget& RadarTarg
 	}
 }
 
-string AT3Tags::GetAMANDelay(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget) 
+string AT3Tags::GetAMANDelay(CFlightPlan& FlightPlan) 
 {
 	int delay = trunc(GetCurrentDelay(FlightPlan.GetCallsign()));
 	if (delay == 0) {
@@ -891,7 +891,7 @@ string AT3Tags::GetAMANDelay(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
 	}
 }
 
-string AT3Tags::GetCallsign(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetCallsign(CFlightPlan& FlightPlan)
 {
 	string flightStrip = FlightPlan.GetControllerAssignedData().GetFlightStripAnnotation(5); //find TopSky "/cpdlc/" annotations
 
@@ -903,12 +903,12 @@ string AT3Tags::GetCallsign(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
 	}
 }
 
-string AT3Tags::GetADSBCallsign(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetADSBCallsign(CRadarTarget& RadarTarget)
 {
 	return RadarTarget.GetCallsign();
 }
 
-string AT3Tags::GetATYPWTC(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetATYPWTC(CFlightPlan& FlightPlan)
 {
 	string ATYPWTC = "";
 	ATYPWTC += FlightPlan.GetFlightPlanData().GetAircraftFPType();
@@ -916,7 +916,7 @@ string AT3Tags::GetATYPWTC(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
 	return ATYPWTC;
 }
 
-string AT3Tags::GetVSIndicator(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetVSIndicator(CRadarTarget& RadarTarget)
 {
 	string vsIndicator;
 	if (RadarTarget.GetVerticalSpeed() > 200) {
@@ -929,7 +929,7 @@ string AT3Tags::GetVSIndicator(CFlightPlan& FlightPlan, CRadarTarget& RadarTarge
 	return vsIndicator;
 }
 
-string AT3Tags::GetFormattedArrivalRwy(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetFormattedArrivalRwy(CFlightPlan& FlightPlan)
 {
 	if (arptSet.find(FlightPlan.GetFlightPlanData().GetDestination()) != arptSet.end()) {
 		string runway = FlightPlan.GetFlightPlanData().GetArrivalRwy();
@@ -942,7 +942,7 @@ string AT3Tags::GetFormattedArrivalRwy(CFlightPlan& FlightPlan, CRadarTarget& Ra
 	}
 }
 
-string AT3Tags::GetALRT(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+string AT3Tags::GetALRT(CFlightPlan& FlightPlan)
 {
 	// HOW warning
 	if (FlightPlan.GetState() == FLIGHT_PLAN_STATE_TRANSFER_FROM_ME_INITIATED) {

--- a/AT3/AT3Tags.cpp
+++ b/AT3/AT3Tags.cpp
@@ -211,19 +211,24 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 	switch (ItemCode) {
 		case TAG_ITEM_AT3_ALTITUDE:
 			tagOutput = GetFormattedAltitude(RadarTarget);
-			goto endSwitch;
+			break;
 		case TAG_ITEM_AT3_TRACK:
 			tagOutput = GetFormattedTrack(RadarTarget);
-			goto endSwitch;
+			break;
 		case TAG_ITEM_AT3_SPEED:
 			tagOutput = GetFormattedGroundspeed(RadarTarget);
-			goto endSwitch;
+			break;
 		case TAG_ITEM_AT3_VS_INDICATOR:
 			tagOutput = GetVSIndicator(RadarTarget);
-			goto endSwitch;
+			break;
 		case TAG_ITEM_AT3_ADSB_CALLSIGN:
 			tagOutput = GetADSBCallsign(RadarTarget);
-			goto endSwitch;
+			break;
+	}
+
+	if (tagOutput.length() != 0) {
+		strcpy_s(sItemString, 16, tagOutput.substr(0, 15).c_str());
+		return;
 	}
 
 	if (FlightPlan.IsValid()) {
@@ -269,8 +274,6 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 			tagOutput = "";
 		}
 	}
-
-	endSwitch:;
 
 	// Convert string output to character array
 	strcpy_s(sItemString, 16, tagOutput.substr(0, 15).c_str());

--- a/AT3/AT3Tags.cpp
+++ b/AT3/AT3Tags.cpp
@@ -25,6 +25,7 @@ AT3Tags::AT3Tags(COLORREF colorA, COLORREF colorNA, COLORREF colorR) : CPlugIn(E
 	RegisterTagItemType("AT3 AMC Line 4", TAG_ITEM_AT3_AMC_LINE4);
 	RegisterTagItemType("AT3 ETA", TAG_ITEM_AT3_ETA);
 	RegisterTagItemType("AT3 Callsign", TAG_ITEM_AT3_CALLSIGN);
+	RegisterTagItemType("AT3 ADS-B Callsign", TAG_ITEM_AT3_ADSB_CALLSIGN);
 	RegisterTagItemType("AT3 ATYP + WTC", TAG_ITEM_AT3_ATYPWTC);
 	RegisterTagItemType("AT3 VS Indicator", TAG_ITEM_AT3_VS_INDICATOR);
 	RegisterTagItemType("AT3 Arrival Runway", TAG_ITEM_AT3_ARRIVAL_RWY);
@@ -216,6 +217,9 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 			break;
 		case TAG_ITEM_AT3_SPEED:
 			tagOutput = GetFormattedGroundspeed(FlightPlan, RadarTarget);
+			break;
+		case TAG_ITEM_AT3_ADSB_CALLSIGN:
+			tagOutput = GetADSBCallsign(FlightPlan, RadarTarget);
 			break;
 	}
 
@@ -895,6 +899,11 @@ string AT3Tags::GetCallsign(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
 	} else {
 		return FlightPlan.GetCallsign();
 	}
+}
+
+string AT3Tags::GetADSBCallsign(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)
+{
+	return RadarTarget.GetCallsign();
 }
 
 string AT3Tags::GetATYPWTC(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget)

--- a/AT3/AT3Tags.cpp
+++ b/AT3/AT3Tags.cpp
@@ -211,16 +211,16 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 	switch (ItemCode) {
 		case TAG_ITEM_AT3_ALTITUDE:
 			tagOutput = GetFormattedAltitude(FlightPlan, RadarTarget);
-			break;
+			goto endSwitch;
 		case TAG_ITEM_AT3_TRACK:
 			tagOutput = GetFormattedTrack(FlightPlan, RadarTarget);
-			break;
+			goto endSwitch;
 		case TAG_ITEM_AT3_SPEED:
 			tagOutput = GetFormattedGroundspeed(FlightPlan, RadarTarget);
-			break;
+			goto endSwitch;
 		case TAG_ITEM_AT3_ADSB_CALLSIGN:
 			tagOutput = GetADSBCallsign(FlightPlan, RadarTarget);
-			break;
+			goto endSwitch;
 	}
 
 	if (FlightPlan.IsValid()) {
@@ -269,6 +269,8 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 			tagOutput = "";
 		}
 	}
+
+	endSwitch:;
 
 	// Convert string output to character array
 	strcpy_s(sItemString, 16, tagOutput.substr(0, 15).c_str());

--- a/AT3/AT3Tags.cpp
+++ b/AT3/AT3Tags.cpp
@@ -218,6 +218,9 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 		case TAG_ITEM_AT3_SPEED:
 			tagOutput = GetFormattedGroundspeed(FlightPlan, RadarTarget);
 			goto endSwitch;
+		case TAG_ITEM_AT3_VS_INDICATOR:
+			tagOutput = GetVSIndicator(FlightPlan, RadarTarget);
+			goto endSwitch;
 		case TAG_ITEM_AT3_ADSB_CALLSIGN:
 			tagOutput = GetADSBCallsign(FlightPlan, RadarTarget);
 			goto endSwitch;
@@ -254,9 +257,6 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 			break;
 		case TAG_ITEM_AT3_ATYPWTC:
 			tagOutput = GetATYPWTC(FlightPlan, RadarTarget);
-			break;
-		case TAG_ITEM_AT3_VS_INDICATOR:
-			tagOutput = GetVSIndicator(FlightPlan, RadarTarget);
 			break;
 		case TAG_ITEM_AT3_ARRIVAL_RWY:
 			tagOutput = GetFormattedArrivalRwy(FlightPlan, RadarTarget);

--- a/AT3/AT3Tags.cpp
+++ b/AT3/AT3Tags.cpp
@@ -171,14 +171,16 @@ void AT3Tags::OnFlightPlanControllerAssignedDataUpdate(CFlightPlan FlightPlan, i
 
 void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int ItemCode, int TagData, char sItemString[16], int* pColorCode, COLORREF* pRGB, double* pFontSize)
 {
-	if (!FlightPlan.IsValid() || !RadarTarget.IsValid()) {
+	if (!RadarTarget.IsValid()) {
 		return;
 	}
 
-	bool isAT3Item = true;
 
 	*pColorCode = TAG_COLOR_RGB_DEFINED;
-	switch (FlightPlan.GetState()) {
+	*pRGB = colorNotAssumed;
+
+	if (FlightPlan.IsValid()) {
+		switch (FlightPlan.GetState()) {
 		case FLIGHT_PLAN_STATE_NON_CONCERNED:
 			*pRGB = colorNotAssumed;
 			break;
@@ -200,25 +202,30 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 		case FLIGHT_PLAN_STATE_REDUNDANT:
 			*pRGB = colorRedundant;
 			break;
+		}
 	}
 	
-	string tagOutput;
+	string tagOutput = "";
 
 	switch (ItemCode) {
 		case TAG_ITEM_AT3_ALTITUDE:
 			tagOutput = GetFormattedAltitude(FlightPlan, RadarTarget);
 			break;
-		case TAG_ITEM_AT3_ALTITUDE_ASSIGNED:
-			tagOutput = GetFormattedAltitudedAssigned(FlightPlan, RadarTarget);
-			break;
 		case TAG_ITEM_AT3_TRACK:
 			tagOutput = GetFormattedTrack(FlightPlan, RadarTarget);
 			break;
-		case TAG_ITEM_AT3_HEADING_ASSIGNED:
-			tagOutput = GetFormattedHeadingAssigned(FlightPlan, RadarTarget);
-			break;
 		case TAG_ITEM_AT3_SPEED:
 			tagOutput = GetFormattedGroundspeed(FlightPlan, RadarTarget);
+			break;
+	}
+
+	if (FlightPlan.IsValid()) {
+		switch (ItemCode) {
+		case TAG_ITEM_AT3_ALTITUDE_ASSIGNED:
+			tagOutput = GetFormattedAltitudedAssigned(FlightPlan, RadarTarget);
+			break;
+		case TAG_ITEM_AT3_HEADING_ASSIGNED:
+			tagOutput = GetFormattedHeadingAssigned(FlightPlan, RadarTarget);
 			break;
 		case TAG_ITEM_AT3_SPEED_ASSIGNED:
 			tagOutput = GetFormattedSpeedAssigned(FlightPlan, RadarTarget);
@@ -256,13 +263,11 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 			break;
 		default:
 			tagOutput = "";
-			isAT3Item = false;
+		}
 	}
 
 	// Convert string output to character array
-	if (isAT3Item) {
-		strcpy_s(sItemString, 16, tagOutput.substr(0, 15).c_str());
-	}
+	strcpy_s(sItemString, 16, tagOutput.substr(0, 15).c_str());
 }
 
 void AT3Tags::OnTimer(int Counter) {

--- a/AT3/AT3Tags.cpp
+++ b/AT3/AT3Tags.cpp
@@ -176,6 +176,7 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 		return;
 	}
 
+	bool isAT3Item = true;
 
 	*pColorCode = TAG_COLOR_RGB_DEFINED;
 	*pRGB = colorNotAssumed;
@@ -224,59 +225,67 @@ void AT3Tags::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int
 		case TAG_ITEM_AT3_ADSB_CALLSIGN:
 			tagOutput = GetADSBCallsign(RadarTarget);
 			break;
+		default:
+			tagOutput = "";
+			isAT3Item = false;
 	}
 
-	if (tagOutput.length() != 0) {
-		strcpy_s(sItemString, 16, tagOutput.substr(0, 15).c_str());
+	if (isAT3Item) {
+		strcpy_s(sItemString, 16, tagOutput.substr(0, 15).c_str()); 
 		return;
 	}
 
 	if (FlightPlan.IsValid()) {
+		isAT3Item = true;
+
 		switch (ItemCode) {
-		case TAG_ITEM_AT3_ALTITUDE_ASSIGNED:
-			tagOutput = GetFormattedAltitudedAssigned(FlightPlan, RadarTarget);
-			break;
-		case TAG_ITEM_AT3_HEADING_ASSIGNED:
-			tagOutput = GetFormattedHeadingAssigned(FlightPlan);
-			break;
-		case TAG_ITEM_AT3_SPEED_ASSIGNED:
-			tagOutput = GetFormattedSpeedAssigned(FlightPlan);
-			break;
-		case TAG_ITEM_AT3_ROUTE_CODE:
-			tagOutput = GetRouteCodeLine4(FlightPlan);
-			break;
-		case TAG_ITEM_AT3_APPDEP_LINE4:
-			tagOutput = GetAPPDEPLine4(FlightPlan);
-			break;
-		case TAG_ITEM_AT3_AMC_LINE4:
-			tagOutput = GetAMCLine4(FlightPlan);
-			break;
-		case TAG_ITEM_AT3_ETA:
-			tagOutput = GetFormattedETA(FlightPlan, minu);
-			break;
-		case TAG_ITEM_AT3_DELAY:
-			tagOutput = GetAMANDelay(FlightPlan);
-			break;
-		case TAG_ITEM_AT3_CALLSIGN:
-			tagOutput = GetCallsign(FlightPlan);
-			break;
-		case TAG_ITEM_AT3_ATYPWTC:
-			tagOutput = GetATYPWTC(FlightPlan);
-			break;
-		case TAG_ITEM_AT3_ARRIVAL_RWY:
-			tagOutput = GetFormattedArrivalRwy(FlightPlan);
-			break;
-		case TAG_ITEM_AT3_ALRT:
-			tagOutput = GetALRT(FlightPlan);
-			*pRGB = colorRedundant;
-			break;
-		default:
-			tagOutput = "";
+			case TAG_ITEM_AT3_ALTITUDE_ASSIGNED:
+				tagOutput = GetFormattedAltitudedAssigned(FlightPlan, RadarTarget);
+				break;
+			case TAG_ITEM_AT3_HEADING_ASSIGNED:
+				tagOutput = GetFormattedHeadingAssigned(FlightPlan);
+				break;
+			case TAG_ITEM_AT3_SPEED_ASSIGNED:
+				tagOutput = GetFormattedSpeedAssigned(FlightPlan);
+				break;
+			case TAG_ITEM_AT3_ROUTE_CODE:
+				tagOutput = GetRouteCodeLine4(FlightPlan);
+				break;
+			case TAG_ITEM_AT3_APPDEP_LINE4:
+				tagOutput = GetAPPDEPLine4(FlightPlan);
+				break;
+			case TAG_ITEM_AT3_AMC_LINE4:
+				tagOutput = GetAMCLine4(FlightPlan);
+				break;
+			case TAG_ITEM_AT3_ETA:
+				tagOutput = GetFormattedETA(FlightPlan, minu);
+				break;
+			case TAG_ITEM_AT3_DELAY:
+				tagOutput = GetAMANDelay(FlightPlan);
+				break;
+			case TAG_ITEM_AT3_CALLSIGN:
+				tagOutput = GetCallsign(FlightPlan);
+				break;
+			case TAG_ITEM_AT3_ATYPWTC:
+				tagOutput = GetATYPWTC(FlightPlan);
+				break;
+			case TAG_ITEM_AT3_ARRIVAL_RWY:
+				tagOutput = GetFormattedArrivalRwy(FlightPlan);
+				break;
+			case TAG_ITEM_AT3_ALRT:
+				tagOutput = GetALRT(FlightPlan);
+				*pRGB = colorRedundant;
+				break;
+			default:
+				tagOutput = "";
+				isAT3Item = false;
 		}
 	}
 
 	// Convert string output to character array
-	strcpy_s(sItemString, 16, tagOutput.substr(0, 15).c_str());
+	if (isAT3Item) {
+		strcpy_s(sItemString, 16, tagOutput.substr(0, 15).c_str());
+	}
 }
 
 void AT3Tags::OnTimer(int Counter) {

--- a/AT3/AT3Tags.hpp
+++ b/AT3/AT3Tags.hpp
@@ -82,6 +82,8 @@ public:
 
 	string GetCallsign(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
 
+	string GetADSBCallsign(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+
 	string GetATYPWTC(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
 
 	string GetVSIndicator(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);

--- a/AT3/AT3Tags.hpp
+++ b/AT3/AT3Tags.hpp
@@ -54,43 +54,43 @@ public:
 
 	vector<string> GetAvailableRtes(string airport, string runway);
 
-	string GetFormattedAltitude(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetFormattedAltitude(CRadarTarget& RadarTarget);
 
 	string GetFormattedAltitudedAssigned(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
 
-	string GetFormattedTrack(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetFormattedTrack(CRadarTarget& RadarTarget);
 
-	string GetFormattedHeadingAssigned(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetFormattedHeadingAssigned(CFlightPlan& FlightPlan);
 
-	string GetFormattedGroundspeed(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetFormattedGroundspeed(CRadarTarget& RadarTarget);
 
-	string GetFormattedSpeedAssigned(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetFormattedSpeedAssigned(CFlightPlan& FlightPlan);
 
 	void GetRouteCode(CFlightPlan& FlightPlan);
 
-	string GetRouteCodeLine4(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetRouteCodeLine4(CFlightPlan& FlightPlan);
 
 	void GetAssignedAPP(CFlightPlan& FlightPlan);
 
-	string GetAPPDEPLine4(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetAPPDEPLine4(CFlightPlan& FlightPlan);
 
-	string GetAMCLine4 (CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetAMCLine4 (CFlightPlan& FlightPlan);
 
-	string GetFormattedETA(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget, int minutes);
+	string GetFormattedETA(CFlightPlan& FlightPlan, int minutes);
 
-	string GetAMANDelay(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetAMANDelay(CFlightPlan& FlightPlan);
 
-	string GetCallsign(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetCallsign(CFlightPlan& FlightPlan);
 
-	string GetADSBCallsign(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetADSBCallsign(CRadarTarget& RadarTarget);
 
-	string GetATYPWTC(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetATYPWTC(CFlightPlan& FlightPlan);
 
-	string GetVSIndicator(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetVSIndicator(CRadarTarget& RadarTarget);
 
-	string GetFormattedArrivalRwy(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetFormattedArrivalRwy(CFlightPlan& FlightPlan);
 
-	string GetALRT(CFlightPlan& FlightPlan, CRadarTarget& RadarTarget);
+	string GetALRT(CFlightPlan& FlightPlan);
 
 protected:
 	int minu;

--- a/Constant.hpp
+++ b/Constant.hpp
@@ -30,6 +30,7 @@ const int TAG_ITEM_AT3_VS_INDICATOR = 22;
 const int TAG_ITEM_AT3_ARRIVAL_RWY = 23;
 const int TAG_ITEM_AT3_DELAY = 24;
 const int TAG_ITEM_AT3_ALRT = 25;
+const int TAG_ITEM_AT3_ADSB_CALLSIGN = 26;
 
 const int TAG_FUNC_APP_SEL_MENU = 200;
 const int TAG_FUNC_APP_SEL_ITEM_1 = 201;


### PR DESCRIPTION
## Changelog
- Enable some tag items where a flight plan is not provided
    - Altitude
    - Track
    - Ground Speed
    - Vertical Speed Indicator
- Add ADSB callsign tag item for uncorrelated aircraft

<img width="144" height="84" alt="image" src="https://github.com/user-attachments/assets/1a36f8e3-7be4-4779-b82c-741a1a978bee" />

Tag definitions file for ALRT and this PR:
[TagDefinitions.txt](https://github.com/user-attachments/files/21315971/TagDefinitions.txt)
