### PR TITLE
Add proper support for time restrictions which wrap around a day

### DIFF
--- a/VFPC/analyzeFP.cpp
+++ b/VFPC/analyzeFP.cpp
@@ -273,30 +273,25 @@ string CVFPCPlugin::CheckAltitude(int rfl, const json& rules)
 
 		for (const auto& time : rules["time"]) {
 
-			if (time["start"].get<int>() > time["end"].get<int>()) {
-				startTimeGreater = true;
+			bool withinPeriod;
+			startTimeGreater = time["start"].get<int>() > time["end"].get<int>(); // If start time is greater than end time, set bool to true (to allow time periods which wrap around a day to function correctly e.g. 2300-1159z)
+
+			if (startTimeGreater) {
+				withinPeriod = (tm_gmt->tm_hour >= time["start"].get<int>() ||
+					tm_gmt->tm_hour <= time["end"].get<int>());
 			}
 			else {
-				startTimeGreater = false;
-			} // If start time is greater than end time, set bool to true (to allow time periods which wrap around a day to function correctly e.g. 2300-1159z)
+				withinPeriod = (tm_gmt->tm_hour >= time["start"].get<int>() &&
+					tm_gmt->tm_hour <= time["end"].get<int>());
+			}
 			
-			if (startTimeGreater == false) {
-				if (tm_gmt->tm_hour >= time["start"].get<int>() && tm_gmt->tm_hour <= time["end"].get<int>()) {
-					for (const auto& fl : time["unavailableLevels"]) {
-						if (rfl == stoi(fl.get<string>())) {
-							return "FLR"; // Level is time restricted
-						}
+			if (withinPeriod) {
+				for (const auto& fl : time["unavailableLevels"]) {
+					if (rfl == stoi(fl.get<string>())) {
+						return "FLR"; // Level is time restricted
 					}
 				}
-			}
-			else {
-				if (tm_gmt->tm_hour >= time["start"].get<int>() || tm_gmt->tm_hour <= time["end"].get<int>()) {
-					for (const auto& fl : time["unavailableLevels"]) {
-						if (rfl == stoi(fl.get<string>())) {
-							return "FLR"; // Level is time restricted
-						}
-					}
-				}
+				// Loop through available levels
 			}
 		}
 	}

--- a/VFPC/analyzeFP.cpp
+++ b/VFPC/analyzeFP.cpp
@@ -274,7 +274,7 @@ string CVFPCPlugin::CheckAltitude(int rfl, const json& rules)
 			if (tm_gmt->tm_hour >= time["start"].get<int>() && tm_gmt->tm_hour <= time["end"].get<int>()) {
 				for (const auto& fl : time["unavailableLevels"]) {
 					if (rfl == stoi(fl.get<string>())) {
-						return "FLR"; // Level is time restricted
+							return "FLR"; // Level is time restricted
 					}
 				}
 			}

--- a/VFPC/analyzeFP.cpp
+++ b/VFPC/analyzeFP.cpp
@@ -257,7 +257,7 @@ bool CVFPCPlugin::IsAirwayMatch(const string& route, const json& rule)
 	return IsStringInList(newRoute, airways);
 }
 
-string CVFPCPlugin::CheckAltitude(int rfl, const json& rules)
+string CVFPCPlugin::CheckAltitude(int rfl, const json& rules, const string& destination)
 {
 	// Check for time restrictions (ENVAR M750 DADON G581)
 	rfl = rfl / 100;
@@ -282,6 +282,15 @@ string CVFPCPlugin::CheckAltitude(int rfl, const json& rules)
 	if (rules.contains("allowed_fls")) {
 		for (const auto& fl : rules["allowed_fls"]) {
 			if (rfl == stoi(fl.get<string>())) {
+				if (rules.contains("restrictedDestinations")) {
+					for (const auto& dest : rules["restrictedDestinations"]) {
+						for (const auto& level : dest["restrictedLevels"]) {
+							if (rfl == stoi(level.get<string>()) && destination.find(dest["icaoStartsWith"].get<string>()) == string::npos) { // Check if destination starts with the provided ICAO
+								return "FLR";
+							}
+						}
+					}
+				}
 				return "OK";
 			}
 		}
@@ -325,7 +334,7 @@ string CVFPCPlugin::ValidateRules(const json& rule, const string& destination, c
 			return "CHK"; // Airway mismatch
 		}
 
-		return CheckAltitude(rfl, rule); // Check altitude restrictions
+		return CheckAltitude(rfl, rule, destination); // Check altitude restrictions
 	}
 	catch (...) {
 		return "CHK";

--- a/VFPC/analyzeFP.cpp
+++ b/VFPC/analyzeFP.cpp
@@ -288,7 +288,7 @@ string CVFPCPlugin::CheckAltitude(int rfl, const json& rules)
 					return "OK";
 			}
 		}
-			return "FLR"; // If RFL does not match allowed_fls
+		return "FLR"; // If RFL does not match allowed_fls
 	}
 
 	// Check max/min flight levels

--- a/VFPC/analyzeFP.cpp
+++ b/VFPC/analyzeFP.cpp
@@ -222,7 +222,10 @@ bool CVFPCPlugin::IsDestinationMatch(const string& destination, const json& rule
 		return true; // No destination restriction
 	}
 	for (const auto& dest : rule["destinations"]) {
-		if (destination.find(dest.get<string>()) != string::npos) {
+		if (destination.find(dest.get<string>()) != string::npos && dest.get<string>().find("*") == string::npos) { // Check if wildcard is present
+			return true;
+		}
+		else if (destination.rfind(dest.get<string>().substr(0, dest.get<string>().find("*")), 0) == 0) { // Check if ICAO starts with required prefix
 			return true;
 		}
 	}
@@ -257,7 +260,7 @@ bool CVFPCPlugin::IsAirwayMatch(const string& route, const json& rule)
 	return IsStringInList(newRoute, airways);
 }
 
-string CVFPCPlugin::CheckAltitude(int rfl, const json& rules, const string& destination)
+string CVFPCPlugin::CheckAltitude(int rfl, const json& rules)
 {
 	// Check for time restrictions (ENVAR M750 DADON G581)
 	rfl = rfl / 100;
@@ -282,19 +285,10 @@ string CVFPCPlugin::CheckAltitude(int rfl, const json& rules, const string& dest
 	if (rules.contains("allowed_fls")) {
 		for (const auto& fl : rules["allowed_fls"]) {
 			if (rfl == stoi(fl.get<string>())) {
-				if (rules.contains("restrictedDestinations")) {
-					for (const auto& dest : rules["restrictedDestinations"]) {
-						for (const auto& level : dest["restrictedLevels"]) {
-							if (rfl == stoi(level.get<string>()) && destination.find(dest["icaoStartsWith"].get<string>()) == string::npos) { // Check if destination starts with the provided ICAO
-								return "FLR";
-							}
-						}
-					}
-				}
-				return "OK";
+					return "OK";
 			}
 		}
-		return "FLR"; // If RFL does not match allowed_fls
+			return "FLR"; // If RFL does not match allowed_fls
 	}
 
 	// Check max/min flight levels
@@ -334,7 +328,7 @@ string CVFPCPlugin::ValidateRules(const json& rule, const string& destination, c
 			return "CHK"; // Airway mismatch
 		}
 
-		return CheckAltitude(rfl, rule, destination); // Check altitude restrictions
+		return CheckAltitude(rfl, rule); // Check altitude restrictions
 	}
 	catch (...) {
 		return "CHK";

--- a/VFPC/analyzeFP.cpp
+++ b/VFPC/analyzeFP.cpp
@@ -269,12 +269,32 @@ string CVFPCPlugin::CheckAltitude(int rfl, const json& rules)
 		time_t curr_time;
 		curr_time = time(NULL);
 		tm* tm_gmt = gmtime(&curr_time);
+		bool startTimeGreater = false;
 
 		for (const auto& time : rules["time"]) {
-			if (tm_gmt->tm_hour >= time["start"].get<int>() && tm_gmt->tm_hour <= time["end"].get<int>()) {
-				for (const auto& fl : time["unavailableLevels"]) {
-					if (rfl == stoi(fl.get<string>())) {
-						return "FLR"; // Level is time restricted
+
+			if (time["start"].get<int>() > time["end"].get<int>()) {
+				startTimeGreater = true;
+			}
+			else {
+				startTimeGreater = false;
+			} // If start time is greater than end time, set bool to true (to allow time periods which wrap around a day to function correctly e.g. 2300-1159z)
+			
+			if (startTimeGreater == false) {
+				if (tm_gmt->tm_hour >= time["start"].get<int>() && tm_gmt->tm_hour <= time["end"].get<int>()) {
+					for (const auto& fl : time["unavailableLevels"]) {
+						if (rfl == stoi(fl.get<string>())) {
+							return "FLR"; // Level is time restricted
+						}
+					}
+				}
+			}
+			else {
+				if (tm_gmt->tm_hour >= time["start"].get<int>() || tm_gmt->tm_hour <= time["end"].get<int>()) {
+					for (const auto& fl : time["unavailableLevels"]) {
+						if (rfl == stoi(fl.get<string>())) {
+							return "FLR"; // Level is time restricted
+						}
 					}
 				}
 			}

--- a/VFPC/analyzeFP.cpp
+++ b/VFPC/analyzeFP.cpp
@@ -222,7 +222,7 @@ bool CVFPCPlugin::IsDestinationMatch(const string& destination, const json& rule
 		return true; // No destination restriction
 	}
 	for (const auto& dest : rule["destinations"]) {
-		if (destination.find(dest.get<string>()) != string::npos && dest.get<string>().find("*") == string::npos) { // Check if wildcard is present
+		if (destination.find(dest.get<string>()) != string::npos) { // Check if wildcard is present
 			return true;
 		}
 		else if (destination.rfind(dest.get<string>().substr(0, dest.get<string>().find("*")), 0) == 0) { // Check if ICAO starts with required prefix

--- a/VFPC/analyzeFP.cpp
+++ b/VFPC/analyzeFP.cpp
@@ -259,8 +259,26 @@ bool CVFPCPlugin::IsAirwayMatch(const string& route, const json& rule)
 
 string CVFPCPlugin::CheckAltitude(int rfl, const json& rules)
 {
-	// Check allowed flight levels
+	// Check for time restrictions (ENVAR M750 DADON G581)
 	rfl = rfl / 100;
+	if (rules.contains("time")) {
+
+		time_t curr_time;
+		curr_time = time(NULL);
+		tm* tm_gmt = gmtime(&curr_time);
+
+		for (const auto& time : rules["time"]) {
+			if (tm_gmt->tm_hour >= time["start"].get<int>() && tm_gmt->tm_hour <= time["end"].get<int>()) {
+				for (const auto& fl : time["unavailableLevels"]) {
+					if (rfl == stoi(fl.get<string>())) {
+						return "FLR"; // Level is time restricted
+					}
+				}
+			}
+		}
+	}
+
+	// Check allowed flight levels
 	if (rules.contains("allowed_fls")) {
 		for (const auto& fl : rules["allowed_fls"]) {
 			if (rfl == stoi(fl.get<string>())) {

--- a/VFPC/analyzeFP.cpp
+++ b/VFPC/analyzeFP.cpp
@@ -274,7 +274,7 @@ string CVFPCPlugin::CheckAltitude(int rfl, const json& rules)
 			if (tm_gmt->tm_hour >= time["start"].get<int>() && tm_gmt->tm_hour <= time["end"].get<int>()) {
 				for (const auto& fl : time["unavailableLevels"]) {
 					if (rfl == stoi(fl.get<string>())) {
-							return "FLR"; // Level is time restricted
+						return "FLR"; // Level is time restricted
 					}
 				}
 			}

--- a/VFPC/analyzeFP.cpp
+++ b/VFPC/analyzeFP.cpp
@@ -285,7 +285,7 @@ string CVFPCPlugin::CheckAltitude(int rfl, const json& rules)
 	if (rules.contains("allowed_fls")) {
 		for (const auto& fl : rules["allowed_fls"]) {
 			if (rfl == stoi(fl.get<string>())) {
-					return "OK";
+				return "OK";
 			}
 		}
 		return "FLR"; // If RFL does not match allowed_fls

--- a/VFPC/analyzeFP.hpp
+++ b/VFPC/analyzeFP.hpp
@@ -60,7 +60,7 @@ public:
 
 	bool IsAirwayMatch(const string& route, const json& rule);
 
-	string CheckAltitude(int rfl, const json& rules);
+	string CheckAltitude(int rfl, const json& rules, const string& destination);
 
 	string ValidateRules(const json& rule, const string& destination, const string& route, int rfl);
 

--- a/VFPC/analyzeFP.hpp
+++ b/VFPC/analyzeFP.hpp
@@ -60,7 +60,7 @@ public:
 
 	bool IsAirwayMatch(const string& route, const json& rule);
 
-	string CheckAltitude(int rfl, const json& rules, const string& destination);
+	string CheckAltitude(int rfl, const json& rules);
 
 	string ValidateRules(const json& rule, const string& destination, const string& route, int rfl);
 


### PR DESCRIPTION
Time restrictions which wrap around a day (e.g. 2300 - 1159z) are presently not implemented correctly, as VFPC would continue to output "OK" for such a restriction even if the current UTC time falls within that range. This PR resolves that issue.